### PR TITLE
App method updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Adds a device to your application, giving your application access to that device
 
 Note that, with the exception of enterprise applications, the user must have granted access to the device through the MyVinli OAuth flow.
 
+#### `removeDevice(deviceId)`
+
+Removes the device associated with the given `deviceId` from your application.
 
 #### `devices(options)`
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -17,6 +17,12 @@ module.exports = function(client) {
       });
     },
 
+    removeDevice: function(deviceId) {
+      Joi.assert(deviceId, Joi.string().required());
+
+      return client.delete('platform', 'devices/' + deviceId);
+    },
+
     devices: function(_options) {
       var self = this;
       _options = Hoek.applyToDefaults({ offset: 0, limit: 20 }, _options);

--- a/test/app_tests.js
+++ b/test/app_tests.js
@@ -138,4 +138,26 @@ describe('App', function() {
       }).to.throw(/id, caseId/);
     });
   });
+
+  describe('.removeDevice()', function() {
+    it('should exist', function() {
+      expect(Vinli.App).to.have.property('removeDevice').that.is.a('function');
+    });
+
+    it('should let you remove a device by device id', function() {
+      var m = nock('https://platform.vin.li')
+      .delete('/api/v1/devices/foo')
+      .reply(204);
+
+      return Vinli.App.removeDevice('foo').then(function() {
+        m.done();
+      });
+    });
+
+    it('should not let you remove a device without device id', function() {
+      expect(function() {
+        Vinli.App.removeDevice();
+      }).to.throw(/required/);
+    });
+  });
 });

--- a/test/app_tests.js
+++ b/test/app_tests.js
@@ -134,7 +134,7 @@ describe('App', function() {
 
     it('should not let you add a device without device id or case id', function() {
       expect(function() {
-        Vinli.App.addDevice({ id: 'foo', caseId: 'VNL999' });
+        Vinli.App.addDevice({});
       }).to.throw(/id, caseId/);
     });
   });


### PR DESCRIPTION
Two main updates in this PR:

1. Update `App.addDevice` test to properly test error when no device `id` or `caseId` are passed
2. Addition of `App.removeDevice` method, test, and documentation for de-registering a device
    - _Reference: [Vinli Docs - Deregister A Device](http://docs.vin.li/en/latest/web/API-reference/index.html#deregister-a-device)_